### PR TITLE
ci: Github Pages build + deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,61 @@
+name: Build & Deploy to GitHub Pages
+
+# ------------- TRIGGERS -------------
+on:
+  push:
+    branches: [ "main" ]          # after a PR merges into main, do a prod deploy
+  pull_request:                    # on PRs, just build to catch errors (no deploy)
+  workflow_dispatch:               # allow manual runs from the Actions tab
+
+# ------------- PERMISSIONS -------------
+permissions:
+  contents: read                   # read repo
+  pages: write                     # publish to Pages
+  id-token: write                  # required by the deploy step
+
+# ------------- AVOID DUPLICATES -------------
+concurrency:
+  group: "pages"                   # only keep the newest run for this workflow
+  cancel-in-progress: true
+
+jobs:
+  # ===== BUILD JOB (runs for PRs and pushes) =====
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Pulls  repo into the runner so actions can see files
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+       # Preps the Pages environment (base path, etc.)
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      # Runs Jekyll (using your Gemfile if present) and writes a static site to ./_site
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          # Site content lives in ./src
+          source: ./src
+          # Where to put the built site on the runner
+          destination: ./_site
+
+      # Stores ./_site as a build artifact    
+      - name: Upload artifact for deployment
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: _site            # upload the built site as an artifact
+
+  # ===== DEPLOY JOB (only for push -> main) =====
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build                   # wait for build to finish and provide artifact
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages           # special Pages environment
+      url: ${{ steps.deployment.outputs.page_url }}  # final URL shown in job summary
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        # This takes the uploaded artifact from the build job and publishes it

--- a/src/_config.yml
+++ b/src/_config.yml
@@ -25,7 +25,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://samdavisomekara.com" # the base hostname & protocol for your site, e.g. http://example.com
 github_username:  oSamDavis
 collections:
   experiences:


### PR DESCRIPTION
Sets up continuous integration for building and deploying:
* Runs Build + Build on pushes to main. 
* Runs Build on Each Pull Request.